### PR TITLE
added strided_iterator to namespace MCBooster

### DIFF
--- a/mcbooster/strided_iterator.h
+++ b/mcbooster/strided_iterator.h
@@ -1,3 +1,4 @@
+
 /*
  * strided_iterator.h
  *
@@ -33,6 +34,7 @@
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/functional.h>
 
+namespace MCBooster{
 /** \class strided_range
  * Strided range iterator original code: https://github.com/thrust/thrust/blob/master/examples/strided_range.cu
  */
@@ -89,5 +91,5 @@ protected:
 	Iterator last;
 	difference_type stride;
 };
-
+}
 #endif /* STRIDED_ITERATOR_H_ */


### PR DESCRIPTION
Just a minor tiny change, but this way everything is cleanly inside the MCBooster namespace and doesn't cause any conflicts when integrating the library into other projects.
